### PR TITLE
Rename users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  self.table_name = 'stripe_users'
   pay_customer default_payment_processor: :stripe
   # include Pay::Billable
   # Include default devise modules. Others available are:

--- a/db/migrate/20250216212521_rename_users_to_stripe_users.rb
+++ b/db/migrate/20250216212521_rename_users_to_stripe_users.rb
@@ -1,0 +1,5 @@
+class RenameUsersToStripeUsers < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :users, :stripe_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_05_210606) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_16_212521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,7 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_05_210606) do
     t.string "status"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "stripe_users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -118,8 +118,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_05_210606) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["email"], name: "index_stripe_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_stripe_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "pay_charges", "pay_customers", column: "customer_id"


### PR DESCRIPTION
Render stores all the tables in a single DB. Since there is already a table named "users", I changed the table name to "stripe_users".